### PR TITLE
add self to hackny pokdex

### DIFF
--- a/hackNY-pokedex.json
+++ b/hackNY-pokedex.json
@@ -745,5 +745,10 @@ cohorts 2010 * 2011 * 2012 * 2013 * 2014
       "name":"Wayne Chang",
       "university":"Rutgers University",
       "pokemon":"Dragonair"
+   },
+   {
+      "name":"Sakib Jalal",
+      "university":"Rutgers University",
+      "pokemon":"Dragonite"
    }
 ]


### PR DESCRIPTION
I just found this through Matt "Cool Porygon" Condon's alumNY update and Dragonite is my all-time favorite pokemon. I'm in the 2016 cohort though.

Also I just noticed magikarp.rb does this through scraping :( Can this pokedex idea be continued?